### PR TITLE
Add LMIC_getSeqnoUp() API, primarily for debugging.

### DIFF
--- a/src/lmic/lmic.c
+++ b/src/lmic/lmic.c
@@ -2292,3 +2292,11 @@ void LMIC_setLinkCheckMode (bit_t enabled) {
     LMIC.adrChanged = 0;
     LMIC.adrAckReq = enabled ? LINK_CHECK_INIT : LINK_CHECK_OFF;
 }
+
+// \brief return the current uplink sequence number.
+// This simple getter returns the uplink sequence number maintained by the LMIC engine.
+// It's useful in debugging, as it allows you to correlate a debug trace event with
+// a specific packet sent over the air.
+u4_t LMIC_getSeqnoUp(void) {
+    return LMIC.seqnoUp;
+}

--- a/src/lmic/lmic.h
+++ b/src/lmic/lmic.h
@@ -294,6 +294,8 @@ void  LMIC_tryRejoin     (void);
 void LMIC_setSession (u4_t netid, devaddr_t devaddr, xref2u1_t nwkKey, xref2u1_t artKey);
 void LMIC_setLinkCheckMode (bit_t enabled);
 
+u4_t LMIC_getSeqnoUp	(void);
+
 // Declare onEvent() function, to make sure any definition will have the
 // C conventions, even when in a C++ file.
 DECL_ON_LMIC_EVENT;


### PR DESCRIPTION
It's convenient to be able to record the transmit sequence number. Add this API so that the upper levels don't need knowledge of the guts of the LMIC data structures.
