### PR TITLE
Added a feature to be able to work even with no DIO pin connected

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,12 +382,36 @@ const lmic_pinmap lmic_pins = {
 #### LoRa Nexus by Ideetron
 This board uses the following pin mapping:
 
+```arduino
     const lmic_pinmap lmic_pins = {
         .nss = 10,
         .rxtx = LMIC_UNUSED_PIN,
         .rst = LMIC_UNUSED_PIN, // hardwired to AtMega RESET
         .dio = {4, 5, 7},
     };
+```
+
+### LoPy (ESP32)
+ When using the LoPy you will need the following pin mapping:
+ 
+ ```
+ const lmic_pinmap lmic_pins = {
+     .mosi = 27,
+     .miso = 19,
+     .sck = 5,
+     .nss = 17,
+     .rxtx = LMIC_UNUSED_PIN,
+     .rst = 18,
+     .dio = {23, 23, 23}, //workaround to use 1 pin for all 3 radio dio pins
+ };
+ ```
+ You will also need Arduino ESP32 support from
+ https://github.com/espressif/arduino-esp32. Use the "ESP32 Dev Module" as target
+ device. To program the LoPy you need to be in bootloader mode. While shorting
+ pin P3 (G23) to ground, push the reset button to put the LoPy in bootloader
+ mode. After programming reset the board without P3 shorted to ground to start
+ in normal mode.
+
 
 Examples
 --------

--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ This board uses the following pin mapping:
      .nss = 17,
      .rxtx = LMIC_UNUSED_PIN,
      .rst = 18,
-     .dio = {23, 23, 23}, //workaround to use 1 pin for all 3 radio dio pins
+     .dio = {23, LMIC_UNUSED_PIN, LMIC_UNUSED_PIN}, 
  };
  ```
  You will also need Arduino ESP32 support from
@@ -411,6 +411,26 @@ This board uses the following pin mapping:
  pin P3 (G23) to ground, push the reset button to put the LoPy in bootloader
  mode. After programming reset the board without P3 shorted to ground to start
  in normal mode.
+
+ ### Heltec Lora32 (ESP32)
+ When using Heltec Lora32 you will need the following pin mapping:
+ 
+ ```
+ const lmic_pinmap lmic_pins = {
+     .mosi = 27,
+     .miso = 19,
+     .sck = 5,
+     .nss = 18,
+     .rxtx = LMIC_UNUSED_PIN,
+     .rst = 14,
+     .dio = {26, 33, 32}, 
+ };
+
+ ```
+ On Board OLED is I2C with SCL=GPIO15, SDA=GPIO4 and OLED_RST=GPIO16.
+ You will also need Arduino ESP32 support from
+ https://github.com/espressif/arduino-esp32. Use the "ESP32 Dev Module" as target
+ device.
 
 
 Examples

--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ If you used 3 diodes OR hardware trick like in this [schematic](https://github.c
 just indicate which GPIO is used on DIO0 definition as follow:
 
 ```arduino
-// Example with 3 DIO OR'ed on one pin connected to GPIO14
+// Example with 3 DIO OR'ed on one pin connected to GPIO15
 const lmic_pinmap lmic_pins = {
     .nss = 16,
     .rxtx = LMIC_UNUSED_PIN,

--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ library what pin you used through the pin mapping (see below).
 [SPI]: https://www.arduino.cc/en/Reference/SPI
 
 ### DIO pins
+
 The DIO (digitial I/O) pins on the transceiver board can be configured
 for various functions. The LMIC library uses them to get instant status
 information from the transceiver. For example, when a LoRa transmission
@@ -254,6 +255,11 @@ DIOx pins can be left disconnected. On the Arduino side, they can
 connect to any I/O pin, since the current implementation does not use
 interrupts or other special hardware features (though this might be
 added in the feature, see also the "Timing" section).
+
+A new software feature has been added to remove needing DIO connections. 
+Of course, you can continue to use DIO mapping has described above 
+but in case you're restricted in GPIO available, but for now you can use
+LMIC using no DIO to any GPIO connection (see below).
 
 In LoRa mode the DIO pins are used as follows:
  * DIO0: TxDone and RxDone
@@ -324,12 +330,54 @@ The names refer to the pins on the transceiver side, the numbers refer
 to the Arduino pin numbers (to use the analog pins, use constants like
 `A0`). For the DIO pins, the three numbers refer to DIO0, DIO1 and DIO2
 respectively. Any pins that are not needed should be specified as
-`LMIC_UNUSED_PIN`. The nss and dio0 pin is required, the others can
+`LMIC_UNUSED_PIN`. Only the nss pin is required, the others can
 potentially left out (depending on the environments and requirements,
 see the notes above for when a pin can or cannot be left out).
 
 The name of this struct must always be `lmic_pins`, which is a special name
 recognized by the library.
+
+Since now, a software feature has been added to remove needing DIO connections. 
+Of course, you can continue to use DIO mapping has follow. to activate this 
+feature, you just need to declare 3 .dio to LMIC_UNUSED_PIN, in your sketch as 
+detailled below. 
+
+If you want to use hardware IRQ but not having 3 IO pins, another trick is
+to OR DIO0/DOI1/DIO2 into one. This is possible because the stack check 
+all IRQs, even if only one is triggered. Doing this is quite easy, just add 3
+1N4148 diodes to each output and a pulldown resistor, see schematic example
+on [WeMos Lora shield](https://github.com/hallard/WeMos-Lora).
+
+If you still have DIO connection, following original lib readme is explaining
+how they work.
+
+If you don't have any DIO pins connected to GPIO (new software feature)
+you just need to declare 3 .dio to LMIC_UNUSED_PIN, in your sketch 
+That's all, stack will do the job for you.
+
+#### [WeMos Lora Shield](https://github.com/hallard/WeMos-Lora)
+```arduino
+// Example with NO DIO pin connected
+const lmic_pinmap lmic_pins = {
+    .nss = 16,
+    .rxtx = LMIC_UNUSED_PIN,
+    .rst = LMIC_UNUSED_PIN,
+    .dio = {LMIC_UNUSED_PIN, LMIC_UNUSED_PIN, LMIC_UNUSED_PIN},
+};
+```
+
+If you used 3 diodes OR hardware trick like in this [schematic](https://github.com/hallard/WeMos-Lora),
+just indicate which GPIO is used on DIO0 definition as follow:
+
+```arduino
+// Example with 3 DIO OR'ed on one pin connected to GPIO14
+const lmic_pinmap lmic_pins = {
+    .nss = 16,
+    .rxtx = LMIC_UNUSED_PIN,
+    .rst = LMIC_UNUSED_PIN,
+    .dio = {15, LMIC_UNUSED_PIN, LMIC_UNUSED_PIN},
+};
+```
 
 #### LoRa Nexus by Ideetron
 This board uses the following pin mapping:

--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ If you want to use hardware IRQ but not having 3 IO pins, another trick is
 to OR DIO0/DOI1/DIO2 into one. This is possible because the stack check 
 all IRQs, even if only one is triggered. Doing this is quite easy, just add 3
 1N4148 diodes to each output and a pulldown resistor, see schematic example
-on [WeMos Lora shield](https://github.com/hallard/WeMos-Lora).
+on [WeMos Lora shield](https://github.com/hallard/WeMos-Lora#schematic).
 
 If you still have DIO connection, following original lib readme is explaining
 how they work.

--- a/project_config/lmic_project_config.h
+++ b/project_config/lmic_project_config.h
@@ -1,4 +1,31 @@
 // project-specific definitions for otaa sensor
+
+// even if you have lora_project_config.h in your sketch directory.
+// some define are not used in all stack at compilation time, 
+// even adding #include "lora_project_config.h" at top of the sketch
+// so put all in this file and it works all time
+
+// Arduino Zero remap Serial to SerialUSB
+#ifdef ARDUINO_ARCH_SAMD          
+#define Serial SerialUSB
+#endif
+
 #define CFG_us915 1
+//#define CFG_eu868 1
 #define CFG_sx1276_radio 1
+
+// Use real interrupts
 //#define LMIC_USE_INTERRUPTS
+
+// Set SPI 8MHz
+//#define LMIC_SPI_FREQ 8000000
+
+// Enable Debug (uncomment both lines)
+//#define LMIC_DEBUG_LEVEL 2
+//#define LMIC_PRINTF_TO Serial
+
+// Use Original AES (More space but quicker)
+//#define USE_ORIGINAL_AES
+
+
+

--- a/src/hal/hal.cpp
+++ b/src/hal/hal.cpp
@@ -142,8 +142,21 @@ static void hal_io_check() {
 static const SPISettings settings(LMIC_SPI_FREQ, MSBFIRST, SPI_MODE0);
 
 static void hal_spi_init () {
-    SPI.begin();
+    #if defined(ESP32)
+      // On the ESP32 the default is _use_hw_ss(false), 
+      // so we can set the last parameter to anything.
+      SPI.begin(lmic_pins.sck, lmic_pins.miso, lmic_pins.mosi, 0x00);
+    #elif defined(NRF51)
+      SPI.begin(lmic_pins.sck, lmic_pins.mosi, lmic_pins.miso);
+    #else
+      //unknown board, or board without SPI pin select ability
+      SPI.begin(); 
+    #endif
 }
+
+
+
+
 
 void hal_pin_nss (u1_t val) {
     if (!val)

--- a/src/hal/hal.h
+++ b/src/hal/hal.h
@@ -12,12 +12,25 @@
 
 static const int NUM_DIO = 3;
 
-struct lmic_pinmap {
-    u1_t nss;
-    u1_t rxtx;
-    u1_t rst;
-    u1_t dio[NUM_DIO];
-};
+#if defined(ESP32) || defined(NRF51)
+  #define LMIC_SPI_PINS_IN_MAPPING
+  struct lmic_pinmap {
+      u1_t mosi;
+      u1_t miso;
+      u1_t sck;
+      u1_t nss;
+      u1_t rxtx;
+      u1_t rst;
+      u1_t dio[NUM_DIO];
+  };
+#else
+  struct lmic_pinmap {
+      u1_t nss;
+      u1_t rxtx;
+      u1_t rst;
+      u1_t dio[NUM_DIO];
+  };
+#endif
 
 // Use this for any unused pins.
 const u1_t LMIC_UNUSED_PIN = 0xff;

--- a/src/lmic/config.h
+++ b/src/lmic/config.h
@@ -60,6 +60,10 @@
 // current implementation only works on AVR, though.
 //#define LMIC_PRINTF_TO Serial
 
+#if LMIC_DEBUG_LEVEL > 0 && ! defined(LMIC_PRINTF_TO)
+# error "You defined LMIC_DEBUG_LEVEL, please also define LMIC_PRINTF_TO to see debug log"
+#endif
+
 // Enable this to use interrupt handler routines listening for RISING signals.
 // Otherwise, the library polls digital input lines for changes.
 //#define LMIC_USE_INTERRUPTS

--- a/src/lmic/hal.h
+++ b/src/lmic/hal.h
@@ -100,6 +100,20 @@ u1_t hal_checkTimer (u4_t targettime);
  */
 void hal_failed (const char *file, u2_t line);
 
+// printf Wrapper
+#ifdef LMIC_PRINTF_TO
+
+/*
+ * perform printf like action.
+ *   - called when LMIC_PRINTF_TO used
+ *   - action printf
+ */
+void hal_printf(char *fmt, ... );
+
+#define printf hal_printf
+
+#endif
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/src/lmic/oslmic.h
+++ b/src/lmic/oslmic.h
@@ -97,6 +97,7 @@ u1_t radio_rand1 (void);
 #define DECLARE_LMIC extern struct lmic_t LMIC
 
 void radio_init (void);
+u1_t radio_has_irq (void);
 void radio_irq_handler (u1_t dio);
 void os_init (void);
 void os_runloop (void);


### PR DESCRIPTION
If the three DIO pin are declared as `LMIC_UNUSED_PIN`, then pool IRQ register from radio Module to detect changes. This permit working only with SPI connections.
You just need to declare 3 .dio to LMIC_UNUSED_PIN, in your sketch and LMIC stack will do the job for you.

```arduino
// Example with NO DIO pin connected
const lmic_pinmap lmic_pins = {
    .nss = 16,
    .rxtx = LMIC_UNUSED_PIN,
    .rst = LMIC_UNUSED_PIN,
    .dio = {LMIC_UNUSED_PIN, LMIC_UNUSED_PIN, LMIC_UNUSED_PIN},
};
```
